### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check-docs.yaml
+++ b/.github/workflows/build-check-docs.yaml
@@ -1,5 +1,8 @@
 name: Build Check Docs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/ongiolt/giolt/security/code-scanning/3](https://github.com/ongiolt/giolt/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required. Since this workflow only checks out the repository and builds documentation, it likely only needs `contents: read` permission. This ensures the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
