### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check-frontend.yaml
+++ b/.github/workflows/build-check-frontend.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - "frontend/**"
 
+permissions:
+  contents: read
+
 jobs:
   check_changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ongiolt/giolt/security/code-scanning/2](https://github.com/ongiolt/giolt/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow only involves checking out the repository and running build commands, it only needs `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege and prevents unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
