### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ongiolt/giolt/security/code-scanning/1](https://github.com/ongiolt/giolt/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is the minimum required permission for the workflow to check out the repository and run the Biome tool. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
